### PR TITLE
Update clean_install/install_bind

### DIFF
--- a/clean_install/install_bind
+++ b/clean_install/install_bind
@@ -20,6 +20,6 @@ sudo ln -s $CURRENTDIR/../named/dev.zone /var/named/dev.zone
 launchctl load -w /System/Library/LaunchDaemons/org.isc.named.plist
 
 # clear DNS
-dscacheutil -flushcache
+sudo killall -HUP mDNSResponder
 
 echo "Don't forget to add an extra DNS server with ip 127.0.0.1"


### PR DESCRIPTION
sudo dscacheutil -flushcache does not work anymore on Lion/ML according to http://support.apple.com/kb/HT5343
