### PR TITLE
Update .zsh_functions

### DIFF
--- a/zsh/.zsh_functions
+++ b/zsh/.zsh_functions
@@ -11,7 +11,7 @@ find_project_dir() {
 
 # find a project (used for autocompletion)
 find_project() {
-	compadd `find ~/Sites/ -maxdepth 2 -mindepth 2 -type d | cut -d \/ -f 7`
+	compadd `find ~/Sites -maxdepth 2 -mindepth 2 -type d | cut -d \/ -f 6`
 }
 
 # navigate to a project


### PR DESCRIPTION
The slash behind the search term for find makes the path wrong for the results: /Users/jonas/Sites//wrc/gymp.dev

This gets rid of the extra obsolete slash behind Sites.